### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-physics9 (8.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 20:56:56 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/libgz-physics9-bullet-dev.install
+++ b/jammy/debian/libgz-physics9-bullet-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-bullet-dev.install

--- a/jammy/debian/libgz-physics9-bullet.install
+++ b/jammy/debian/libgz-physics9-bullet.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-bullet.install

--- a/jammy/debian/libgz-physics9-core-dev.install
+++ b/jammy/debian/libgz-physics9-core-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-core-dev.install

--- a/jammy/debian/libgz-physics9-dartsim-dev.install
+++ b/jammy/debian/libgz-physics9-dartsim-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-dartsim-dev.install

--- a/jammy/debian/libgz-physics9-dartsim.install
+++ b/jammy/debian/libgz-physics9-dartsim.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-dartsim.install

--- a/jammy/debian/libgz-physics9-dev.install
+++ b/jammy/debian/libgz-physics9-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-dev.install

--- a/jammy/debian/libgz-physics9-heightmap-dev.install
+++ b/jammy/debian/libgz-physics9-heightmap-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-heightmap-dev.install

--- a/jammy/debian/libgz-physics9-mesh-dev.install
+++ b/jammy/debian/libgz-physics9-mesh-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-mesh-dev.install

--- a/jammy/debian/libgz-physics9-sdf-dev.install
+++ b/jammy/debian/libgz-physics9-sdf-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-sdf-dev.install

--- a/jammy/debian/libgz-physics9-tpe-dev.install
+++ b/jammy/debian/libgz-physics9-tpe-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-tpe-dev.install

--- a/jammy/debian/libgz-physics9-tpe.install
+++ b/jammy/debian/libgz-physics9-tpe.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-tpe.install

--- a/jammy/debian/libgz-physics9-tpelib-dev.install
+++ b/jammy/debian/libgz-physics9-tpelib-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-tpelib-dev.install

--- a/jammy/debian/libgz-physics9-tpelib.install
+++ b/jammy/debian/libgz-physics9-tpelib.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics-tpelib.install

--- a/jammy/debian/libgz-physics9.install
+++ b/jammy/debian/libgz-physics9.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-physics.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.