### PR TITLE
Relocate .so files in lib (plugin) packages intead of in development packages

### DIFF
--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-physics9 (9.0.0-4~noble) noble; urgency=medium
+
+  * gz-physics9 9.0.0-4 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Fri, 14 Nov 2025 13:19:41 +0100
+
 gz-physics9 (9.0.0-3~noble) noble; urgency=medium
 
   * gz-physics9 9.0.0-3 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-physics9 (9.0.0-3~noble) noble; urgency=medium
+
+  * gz-physics9 9.0.0-3 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Fri, 14 Nov 2025 12:08:50 +0100
+
 gz-physics9 (9.0.0-2~noble) noble; urgency=medium
 
   * gz-physics9 9.0.0-2 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-physics9 (9.0.0-2~noble) noble; urgency=medium
+
+  * gz-physics9 9.0.0-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Tue, 11 Nov 2025 16:56:46 +0100
+
 gz-physics9 (9.0.0-1~noble) noble; urgency=medium
 
   * gz-physics9 9.0.0-1 release

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -17,15 +17,15 @@ Build-Depends: cmake,
                libgz-plugin4-dev,
                libgz-utils4-dev,
                libgz-utils4-cli-dev,
-# DART from packages.o.o repositories
-               libdart6.13-dev,
-               libdart6.13-collision-bullet-dev,
-               libdart6.13-collision-ode-dev,
-               libdart6.13-external-convhull-3d-dev,
-               libdart6.13-external-ikfast-dev,
-               libdart6.13-external-odelcpsolver-dev,
-               libdart6.13-utils-dev,
-               libdart6.13-utils-urdf-dev,
+# DART from packages.o.o repositories - mandatory on all architectures except armhf
+               libdart6.13-dev [!armhf],
+               libdart6.13-collision-bullet-dev [!armhf],
+               libdart6.13-collision-ode-dev [!armhf],
+               libdart6.13-external-convhull-3d-dev [!armhf],
+               libdart6.13-external-ikfast-dev [!armhf],
+               libdart6.13-external-odelcpsolver-dev [!armhf],
+               libdart6.13-utils-dev [!armhf],
+               libdart6.13-utils-urdf-dev [!armhf],
                libsdformat16-dev
 Vcs-Browser: https://github.com/gazebosim/gz-physics
 Vcs-Git: https://github.com/gazebo-release/gz-physics9-release
@@ -108,7 +108,7 @@ Description: Gazebo Physics classes and functions for robot apps - Shared librar
  Main shared library
 
 Package: libgz-physics9-dartsim-dev
-Architecture: any
+Architecture: amd64 arm64
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),
@@ -145,7 +145,7 @@ Description: Gazebo Physics classes and functions for robot apps - Development f
  Dartsim component, development files
 
 Package: libgz-physics9-dartsim
-Architecture: any
+Architecture: amd64 arm64
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -256,7 +256,7 @@ Architecture: any
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-bullet-dev (= ${binary:Version}),
-         libgz-physics9-dartsim-dev (= ${binary:Version}),
+         libgz-physics9-dartsim-dev (= ${binary:Version}) [!armhf],
          libgz-physics9-heightmap-dev (= ${binary:Version}),
          libgz-physics9-mesh-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -17,15 +17,15 @@ Build-Depends: cmake,
                libgz-plugin4-dev,
                libgz-utils4-dev,
                libgz-utils4-cli-dev,
-# DART from packages.o.o repositories - mandatory on all architectures except armhf
-               libdart6.13-dev [!armhf],
-               libdart6.13-collision-bullet-dev [!armhf],
-               libdart6.13-collision-ode-dev [!armhf],
-               libdart6.13-external-convhull-3d-dev [!armhf],
-               libdart6.13-external-ikfast-dev [!armhf],
-               libdart6.13-external-odelcpsolver-dev [!armhf],
-               libdart6.13-utils-dev [!armhf],
-               libdart6.13-utils-urdf-dev [!armhf],
+# DART from packages.o.o repositories
+               libdart6.13-dev,
+               libdart6.13-collision-bullet-dev,
+               libdart6.13-collision-ode-dev,
+               libdart6.13-external-convhull-3d-dev,
+               libdart6.13-external-ikfast-dev,
+               libdart6.13-external-odelcpsolver-dev,
+               libdart6.13-utils-dev,
+               libdart6.13-utils-urdf-dev,
                libsdformat16-dev
 Vcs-Browser: https://github.com/gazebosim/gz-physics
 Vcs-Git: https://github.com/gazebo-release/gz-physics9-release
@@ -108,7 +108,7 @@ Description: Gazebo Physics classes and functions for robot apps - Shared librar
  Main shared library
 
 Package: libgz-physics9-dartsim-dev
-Architecture: amd64 arm64
+Architecture: any
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),
@@ -145,7 +145,7 @@ Description: Gazebo Physics classes and functions for robot apps - Development f
  Dartsim component, development files
 
 Package: libgz-physics9-dartsim
-Architecture: amd64 arm64
+Architecture: any
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -256,7 +256,7 @@ Architecture: any
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-bullet-dev (= ${binary:Version}),
-         libgz-physics9-dartsim-dev (= ${binary:Version}) [!armhf],
+         libgz-physics9-dartsim-dev (= ${binary:Version}),
          libgz-physics9-heightmap-dev (= ${binary:Version}),
          libgz-physics9-mesh-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -137,6 +137,7 @@ Suggests: libdart-dev (>= 6.12.1+dfsg4) | libdart6.13-dev,
          libdart-external-odelcpsolver-dev (>= 6.12.1+dfsg4) | libdart6.13-external-odelcpsolver-dev,
          libdart-external-ikfast-dev (>= 6.12.1+dfsg4) | libdart6.13-external-ikfast-dev,
          libdart-collision-bullet-dev (>= 6.12.1+dfsg4) | libdart6.13-collision-bullet-dev
+Breaks: libgz-physics9-dartsim (<< 9.0.0-2)
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
@@ -150,6 +151,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-dartsim (<< 9.0.0-2)
+Replaces: libgz-physics9-dartsim (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Dartsim library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -170,6 +173,7 @@ Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-tpe (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-tpe (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -182,6 +186,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-tpe (<< 9.0.0-2)
+Replaces: libgz-physics9-tpe (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - TPE library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -198,6 +204,7 @@ Depends: libgz-cmake5-dev,
          libgz-physics9-tpelib (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-tpelib (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -210,6 +217,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-tpelib (<< 9.0.0-2)
+Replaces: libgz-physics9-typelib (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - TPE library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -233,6 +242,7 @@ Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-bullet (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-bullet (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -245,6 +255,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
+Breaks: libgz-physics9-bullet (<< 9.0.0-2)
+Replaces: libgz-physics9-bullet (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Bullet engine
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -137,7 +137,6 @@ Suggests: libdart-dev (>= 6.12.1+dfsg4) | libdart6.13-dev,
          libdart-external-odelcpsolver-dev (>= 6.12.1+dfsg4) | libdart6.13-external-odelcpsolver-dev,
          libdart-external-ikfast-dev (>= 6.12.1+dfsg4) | libdart6.13-external-ikfast-dev,
          libdart-collision-bullet-dev (>= 6.12.1+dfsg4) | libdart6.13-collision-bullet-dev
-Breaks: libgz-physics9-dartsim (<< 9.0.0-2)
 Multi-Arch: same
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
@@ -151,8 +150,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-dartsim (<< 9.0.0-2)
-Replaces: libgz-physics9-dartsim (<< 9.0.0-2)
+Breaks: libgz-physics9-dartsim-dev (<< 9.0.0-2)
+Replaces: libgz-physics9-dartsim-dev (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Dartsim library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -173,7 +172,6 @@ Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-tpe (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-tpe (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -186,8 +184,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-tpe (<< 9.0.0-2)
-Replaces: libgz-physics9-tpe (<< 9.0.0-2)
+Breaks: libgz-physics9-tpe-dev (<< 9.0.0-2)
+Replaces: libgz-physics9-tpe-dev (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - TPE library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -204,7 +202,6 @@ Depends: libgz-cmake5-dev,
          libgz-physics9-tpelib (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-tpelib (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -217,8 +214,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-tpelib (<< 9.0.0-2)
-Replaces: libgz-physics9-typelib (<< 9.0.0-2)
+Breaks: libgz-physics9-tpelib-dev (<< 9.0.0-2)
+Replaces: libgz-physics9-typelib-dev (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - TPE library
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -242,7 +239,6 @@ Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-bullet (= ${binary:Version}),
          ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-bullet (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Development files
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.
@@ -255,8 +251,8 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Multi-Arch: same
-Breaks: libgz-physics9-bullet (<< 9.0.0-2)
-Replaces: libgz-physics9-bullet (<< 9.0.0-2)
+Breaks: libgz-physics9-bullet-dev (<< 9.0.0-2)
+Replaces: libgz-physics9-bullet-dev (<< 9.0.0-2)
 Description: Gazebo Physics classes and functions for robot apps - Bullet engine
  Gazebo Physics is a component in the Gazebo framework, a set of libraries
  designed to rapidly develop robot applications.

--- a/ubuntu/debian/libgz-physics-bullet-dev.install
+++ b/ubuntu/debian/libgz-physics-bullet-dev.install
@@ -1,5 +1,3 @@
 usr/include/*/physics*/*/physics/bullet*/*
 usr/lib/*/cmake/*-physics-bullet*/*
-usr/lib/*/lib*-physics-bullet*.so
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-bullet*.so
 usr/lib/*/pkgconfig/*-physics-bullet*.pc

--- a/ubuntu/debian/libgz-physics-bullet.install
+++ b/ubuntu/debian/libgz-physics-bullet.install
@@ -1,2 +1,2 @@
-usr/lib/*/lib*-physics-bullet*.so.*
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-bullet*.so.*
+usr/lib/*/lib*-physics-bullet*.so*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-bullet*.so*

--- a/ubuntu/debian/libgz-physics-dartsim-dev.install
+++ b/ubuntu/debian/libgz-physics-dartsim-dev.install
@@ -1,5 +1,3 @@
 usr/include/*/physics*/*/physics/dartsim*/*
 usr/lib/*/cmake/*-physics-dartsim*/*
-usr/lib/*/lib*-physics-dartsim*.so
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-dartsim*.so
 usr/lib/*/pkgconfig/*-physics-dartsim*.pc

--- a/ubuntu/debian/libgz-physics-dartsim.install
+++ b/ubuntu/debian/libgz-physics-dartsim.install
@@ -1,2 +1,2 @@
-usr/lib/*/lib*-physics-dartsim*.so.*
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-dartsim*.so.*
+usr/lib/*/lib*-physics-dartsim*.so*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-dartsim*.so*

--- a/ubuntu/debian/libgz-physics-tpe-dev.install
+++ b/ubuntu/debian/libgz-physics-tpe-dev.install
@@ -1,7 +1,5 @@
 usr/include/*/physics*/*/physics/tpe-plugin/*
 usr/lib/*/cmake/*-physics-tpe-plugin/*
 usr/lib/*/cmake/*-physics-tpe/*
-usr/lib/*/lib*-physics-tpe-plugin.so
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-tpe-plugin.so
 usr/lib/*/pkgconfig/*-physics-tpe-plugin.pc
 usr/lib/*/pkgconfig/*-physics-tpe.pc

--- a/ubuntu/debian/libgz-physics-tpe.install
+++ b/ubuntu/debian/libgz-physics-tpe.install
@@ -1,2 +1,2 @@
-usr/lib/*/lib*-physics-tpe-plugin*.so.*
-usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-tpe-plugin*.so.*
+usr/lib/*/lib*-physics-tpe-plugin*.so*
+usr/lib/*/*-physics-[0-99]/engine-plugins/lib*-physics*-tpe-plugin*.so*

--- a/ubuntu/debian/libgz-physics-tpelib-dev.install
+++ b/ubuntu/debian/libgz-physics-tpelib-dev.install
@@ -1,4 +1,3 @@
 usr/include/*/physics*/*/physics/tpelib/*
 usr/lib/*/cmake/*-physics-tpelib/*
-usr/lib/*/lib*-physics-tpelib.so
 usr/lib/*/pkgconfig/*-physics-tpelib.pc

--- a/ubuntu/debian/libgz-physics-tpelib.install
+++ b/ubuntu/debian/libgz-physics-tpelib.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib*-physics-tpelib*.so.*
+usr/lib/*/lib*-physics-tpelib*.so*


### PR DESCRIPTION
While working on https://github.com/gazebo-release/gz-sim8-release/issues/8 I notice that the installation of the different physics plugins packages (`libgz-physicsX-{dartsim|bullet|tpe}`) is not enough for the gz server to recognize them as being installed since it expects to find the files `libgz-physics-{engine}-plugin.so` and that files are shipped in the development packages (`libgz-physicsX-{dartsim|bullet|tpe}-dev`).

This is common in the shared library packaging practices in Debian but here we are packaging plugins that should be able to "run" without the development package.

Testing the build: [![Build Status](https://build.osrfoundation.org/job/gz-physics9-debbuilder/196/badge/icon)](https://build.osrfoundation.org/job/gz-physics9-debbuilder/196/)