### PR TITLE
Restrict armhf not to build the dart support

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -17,15 +17,15 @@ Build-Depends: cmake,
                libgz-plugin4-dev,
                libgz-utils4-dev,
                libgz-utils4-cli-dev,
-# DART from packages.o.o repositories
-               libdart6.13-dev,
-               libdart6.13-collision-bullet-dev,
-               libdart6.13-collision-ode-dev,
-               libdart6.13-external-convhull-3d-dev,
-               libdart6.13-external-ikfast-dev,
-               libdart6.13-external-odelcpsolver-dev,
-               libdart6.13-utils-dev,
-               libdart6.13-utils-urdf-dev,
+# DART from packages.o.o repositories - mandatory on all architectures except armhf
+               libdart6.13-dev [!armhf],
+               libdart6.13-collision-bullet-dev [!armhf],
+               libdart6.13-collision-ode-dev [!armhf],
+               libdart6.13-external-convhull-3d-dev [!armhf],
+               libdart6.13-external-ikfast-dev [!armhf],
+               libdart6.13-external-odelcpsolver-dev [!armhf],
+               libdart6.13-utils-dev [!armhf],
+               libdart6.13-utils-urdf-dev [!armhf],
                libsdformat16-dev
 Vcs-Browser: https://github.com/gazebosim/gz-physics
 Vcs-Git: https://github.com/gazebo-release/gz-physics9-release
@@ -108,7 +108,7 @@ Description: Gazebo Physics classes and functions for robot apps - Shared librar
  Main shared library
 
 Package: libgz-physics9-dartsim-dev
-Architecture: any
+Architecture: amd64 arm64
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),
@@ -145,7 +145,7 @@ Description: Gazebo Physics classes and functions for robot apps - Development f
  Dartsim component, development files
 
 Package: libgz-physics9-dartsim
-Architecture: any
+Architecture: amd64 arm64
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
@@ -256,7 +256,7 @@ Architecture: any
 Section: libdevel
 Depends: libgz-physics9-core-dev (= ${binary:Version}),
          libgz-physics9-bullet-dev (= ${binary:Version}),
-         libgz-physics9-dartsim-dev (= ${binary:Version}),
+         libgz-physics9-dartsim-dev (= ${binary:Version}) [!armhf],
          libgz-physics9-heightmap-dev (= ${binary:Version}),
          libgz-physics9-mesh-dev (= ${binary:Version}),
          libgz-physics9-sdf-dev (= ${binary:Version}),

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -9,9 +9,14 @@ LDFLAGS:=$(filter-out -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects,
 	dh $@ --no-parallel
 
 override_dh_auto_configure:
+# Skip dartsim on armhf due to lack of support for 32bits in dart upstream
+ifeq ($(DEB_HOST_ARCH),armhf)
 	dh_auto_configure -- \
-		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
-		-DSKIP_dartsim=true
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo -DSKIP_dartsim=true
+else
+	dh_auto_configure -- \
+	-DCMAKE_BUILD_TYPE=RelWithDebInfo
+endif
 
 # test cannot run in parallel
 # arm64 problems https://github.com/gazebosim/gz-physics/issues/70

--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -10,7 +10,8 @@ LDFLAGS:=$(filter-out -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects,
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
+		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
+		-DSKIP_dartsim=true
 
 # test cannot run in parallel
 # arm64 problems https://github.com/gazebosim/gz-physics/issues/70


### PR DESCRIPTION
DART does not support 32bits so we can have gz-physics but without DART

Testing it  [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-physics9-debbuilder&build=209)](https://build.osrfoundation.org/job/gz-physics9-debbuilder/209/) 