### PR TITLE
Add new libgz jetty aliases

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -293,3 +293,20 @@ Priority: optional
 Section: metapackages
 Description: alias package
  Provides a package for Jetty without exposing the version number.
+
+Package: libgz-jetty-physics-dev
+Depends: libgz-physics9-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+
+Package: libgz-jetty-physics-core-dev
+Depends: libgz-physics9-core-dev (= ${binary:Version}), ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: metapackages
+Description: alias package
+ Provides a package for Jetty without exposing the version number.
+


### PR DESCRIPTION
Added the same kind of aliases than the ones used for rotary. See
https://github.com/gazebo-tooling/release-tools/issues/1446